### PR TITLE
Update client-side story name when saving

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -2050,6 +2050,11 @@ def saveRequest(savpath):
             return e
         file.close()
 
+        filename = path.basename(savpath)
+        if(filename.endswith('.json')):
+            filename = filename[:-5]
+        vars.laststory = filename
+        emit('from_server', {'cmd': 'setstoryname', 'data': vars.laststory}, broadcast=True)
         print("{0}Story saved to {1}!{2}".format(colors.GREEN, path.basename(savpath), colors.END))
 
 #==================================================================#

--- a/static/application.js
+++ b/static/application.js
@@ -883,7 +883,7 @@ function downloadStory(format) {
 		authorsnote: $("#anoteinput").val(),
 		actions: actionlist_compiled,
 		worldinfo: wilist_compiled,
-	}, null, 4)]));
+	}, null, 3)]));
 	anchor.setAttribute('href', objectURL);
 	anchor.setAttribute('download', filename_without_extension + ".json");
 	anchor.click();


### PR DESCRIPTION
If you save a story as a different name than it was loaded with, and
then try to download it as JSON/plaintext, the downloaded file's name
will now match the new story name.