### PR TITLE
Soft prompt support for PyTorch models

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -2295,9 +2295,10 @@ def spRequest(filename):
 
     z, version, shape, fortran_order, dtype = fileops.checksp(filename, vars.modeldim)
     assert isinstance(z, zipfile.ZipFile)
+    z.close()
 
-    with z.open('tensor.npy') as f:
-        tensor = np.load(f, allow_pickle=False)
+    with np.load(fileops.sppath(filename), allow_pickle=False) as f:
+        tensor = f['tensor.npy']
 
     # If the tensor is in bfloat16 format, convert it to float32
     if(tensor.dtype == 'V2'):
@@ -2305,7 +2306,8 @@ def spRequest(filename):
         tensor = np.uint32(tensor) << 16
         tensor.dtype = np.float32
 
-    tensor = np.float16(tensor)
+    if(tensor.dtype != np.float16):
+        tensor = np.float32(tensor)
     assert not np.isinf(tensor).any() and not np.isnan(tensor).any()
 
     vars.sp = torch.from_numpy(tensor)

--- a/aiserver.py
+++ b/aiserver.py
@@ -1190,9 +1190,6 @@ def calcsubmit(txt):
         else:
             budget = vars.max_length - lnsp - lnmem - lnanote - lnwi - vars.genamt
 
-        if(vars.sp is not None):
-            budget -= vars.sp.shape[0]
-
         if(actionlen == 0):
             # First/Prompt action
             subtxt = vars.memory + winfo + anotetxt + vars.prompt

--- a/aiserver.py
+++ b/aiserver.py
@@ -534,6 +534,11 @@ if(not vars.model in ["InferKit", "Colab", "OAI", "ReadOnly"]):
             cls.forward = new_causallm_forward
         for cls in (GPT2LMHeadModel, GPTNeoForCausalLM):
             patch_causallm(cls)
+        try:
+            from transformers import GPTJForCausalLM
+            patch_causallm(GPTJForCausalLM)
+        except:
+            pass
 
         # If custom GPT Neo model was chosen
         if(vars.model == "NeoCustom"):

--- a/aiserver.py
+++ b/aiserver.py
@@ -526,7 +526,7 @@ if(not vars.model in ["InferKit", "Colab", "OAI", "ReadOnly"]):
                 inputs_embeds = self.transformer.wte(input_ids)
                 input_ids -= self.config.vocab_size
                 if(vars.sp is not None):
-                    vars.sp = vars.sp.to(inputs_embeds.device)
+                    vars.sp = vars.sp.to(inputs_embeds.dtype).to(inputs_embeds.device)
                     inputs_embeds = torch.where(
                         (input_ids >= 0)[:, :, None],
                         vars.sp[input_ids.clamp(min=0)],

--- a/aiserver.py
+++ b/aiserver.py
@@ -1189,7 +1189,7 @@ def calcsubmit(txt):
         if(actionlen == 0):
             # First/Prompt action
             subtxt = vars.memory + winfo + anotetxt + vars.prompt
-            lnsub  = lnmem + lnwi + lnprompt + lnanote
+            lnsub  = lnsp + lnmem + lnwi + lnprompt + lnanote
             
             if(not vars.model in ["Colab", "OAI"]):
                 generate(subtxt, lnsub+1, lnsub+vars.genamt)

--- a/static/application.js
+++ b/static/application.js
@@ -682,15 +682,18 @@ function buildSPList(ar) {
 			: Object.prototype.toString.call(ar[i].supported) === "[object Array]"
 			? "[" + ar[i].supported.join(', ') + "]"
 			: "[" + ar[i].supported.toString() + "]";
+		var filename = ar[i].filename.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#039;').replace(/(?=\r|\n)\r?\n?/g, '<br/>');
 		var name = ar[i].name || ar[i].filename;
 		name = name.length > 120 ? name.slice(0, 117) + '...' : name;
+		name = name.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#039;').replace(/(?=\r|\n)\r?\n?/g, '<br/>');
 		var desc = ar[i].description || '';
 		desc = desc.length > 500 ? desc.slice(0, 497) + '...' : desc;
+		desc = desc.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#039;').replace(/(?=\r|\n)\r?\n?/g, '<br/>');
 		spcontent.append("<div class=\"flex\">\
 			<div class=\"splistitem flex-row-container\" id=\"sp"+i+"\" name=\""+ar[i].filename+"\">\
 				<div class=\"flex-row\">\
 					<div>"+name+"</div>\
-					<div class=\"flex-push-right splistitemsub\">"+ar[i].filename+"</div>\
+					<div class=\"flex-push-right splistitemsub\">"+filename+"</div>\
 				</div>\
 				<div class=\"flex-row\">\
 					<div>"+desc+"</div>\

--- a/static/custom.css
+++ b/static/custom.css
@@ -307,6 +307,38 @@ chunk.editing, chunk.editing * {
 	overflow-y: scroll;
 }
 
+#sppopup {
+	width: 500px;
+	background-color: #262626;
+	margin-top: 100px;
+}
+
+@media (max-width: 768px) {
+	#loadpopup {
+		width: 100%;
+		background-color: #262626;
+		margin-top: 100px;
+	}
+}
+
+#sppopupdelete {
+	width: 350px;
+	background-color: #262626;
+	margin-top: 200px;
+}
+
+#sppopuprename {
+	width: 350px;
+	background-color: #262626;
+	margin-top: 200px;
+}
+
+#splistcontent {
+	height: 325px;
+	overflow-y: scroll;
+	overflow-wrap: anywhere;
+}
+
 #nspopup {
 	width: 350px;
 	background-color: #262626;
@@ -421,6 +453,18 @@ chunk.editing, chunk.editing * {
 .flex {
 	display: flex;
 	align-items: center;
+}
+
+.flex-row-container {
+	display: flex;
+	flex-flow: wrap;
+}
+
+.flex-row {
+	display: flex;
+	flex-flow: row;
+	flex-grow: 1;
+	width: 100%;
 }
 
 .flex-push-right {
@@ -803,6 +847,34 @@ chunk.editing, chunk.editing * {
 .spacer {
 	display: inline-block;
 	width: 50px;
+}
+
+.splistheader {
+	padding-left: 68px;
+	padding-right: 20px;
+	display: flex;
+	color: #737373;
+}
+
+.splistitem {
+	padding: 12px 10px 12px 10px;
+	display: flex;
+	flex-grow: 1;
+	color: #ffffff;
+	
+	-moz-transition: background-color 0.25s ease-in;
+	-o-transition: background-color 0.25s ease-in;
+	-webkit-transition: background-color 0.25s ease-in;
+	transition: background-color 0.25s ease-in;
+}
+
+.splistitemsub {
+	color: #ba9;
+}
+
+.splistitem:hover {
+	cursor: pointer;
+	background-color: #688f1f;
 }
 
 .width-auto {

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,14 +6,14 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<script src="static/jquery-3.6.0.min.js"></script>
 	<script src="static/socket.io.min.js"></script>
-	<script src="static/application.js?ver=1.16.2j"></script>
+	<script src="static/application.js?ver=1.16.3ua"></script>
 	<script src="static/bootstrap.min.js"></script>
 	<script src="static/bootstrap-toggle.min.js"></script>
 	<script src="static/rangy-core.min.js"></script>
 	
 	<link rel="stylesheet" href="static/bootstrap.min.css">
 	<link rel="stylesheet" href="static/bootstrap-toggle.min.css">
-	<link rel="stylesheet" href="static/custom.css?ver=1.16.2a">
+	<link rel="stylesheet" href="static/custom.css?ver=1.16.3ua">
 	<link rel="stylesheet" href="static/open-iconic-bootstrap.min.css">
 </head>
 <body>
@@ -66,6 +66,9 @@
 								</li>
 								<li class="nav-item">
 									<a class="nav-link" href="#" id="btn_format">Formatting</a>
+								</li>
+								<li class="nav-item">
+									<a class="nav-link hidden" href="#" id="btn_softprompt">Soft Prompt</a>
 								</li>
 							</ul>
 						</div>
@@ -222,6 +225,19 @@
 			<div class="popupfooter">
 				<button type="button" class="btn btn-primary" id="btn_loadaccept">Load</button>
 				<button type="button" class="btn btn-primary" id="btn_loadclose">Cancel</button>
+			</div>
+		</div>
+	</div>
+	<div class="popupcontainer hidden" id="spcontainer">
+		<div id="sppopup">
+			<div class="popuptitlebar">
+				<div class="popuptitletext">Select A Soft Prompt To Use</div>
+			</div>
+			<div id="splistcontent">
+			</div>
+			<div class="popupfooter">
+				<button type="button" class="btn btn-primary" id="btn_spaccept">Load</button>
+				<button type="button" class="btn btn-primary" id="btn_spclose">Cancel</button>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Work In Progress, but for now you can make a folder called "softprompts" and put soft prompts inside it. There will be a button in the top bar of the UI to select a soft prompt. Soft prompts whose tensors are the wrong shape for your current model will not be shown in the list. It does not work yet in the 6B Colabs or in the "Colab" mode of KoboldAI (which is not used by the Colabs anymore).

I decided to invent a new file format for the soft prompts because mkultra's format has an arbitrary code execution vulnerability due to its use of Python's "pickle" module. The new format is a ZIP file with two files inside: meta.json and tensor.npy. Here's a script for converting mkultra JSON format to this one:

```python
import torch
import numpy as np
import zipfile
import pickle, base64, json

in_path = "input.json"
out_path = "output.zip"

meta = {
    "name": "Untitled",
    "author": "You",
    "supported": ["Generic 6B"],
    "description": "Baby shoes",
}

with open(in_path) as f:
    t = pickle.loads(base64.b64decode(json.load(f)["tensor"].encode("ascii")))
if t.ndim == 3:
    t = t.squeeze(0)
assert t.ndim == 2
assert t.shape[0] < 2048
assert t.dtype in (torch.float32, torch.float16, torch.bfloat16)
if t.dtype == torch.bfloat16:
    t = t.to(torch.float32)
    t = t.detach().cpu().numpy()
    t.dtype = np.uint32
    t >>= 16
    t = np.uint16(t)
    t.dtype = "V2"
else:
    t = t.detach().cpu().numpy()
with zipfile.ZipFile(out_path, "w", compression=zipfile.ZIP_LZMA) as z:
    with z.open("tensor.npy", "w") as f:
        np.save(f, t, allow_pickle=False)
with zipfile.ZipFile(out_path, "a", compression=zipfile.ZIP_STORED) as z:
    with z.open("meta.json", "w") as f:
        f.write(json.dumps(meta, indent=2).encode("utf-8"))
```

You can also use https://github.com/VE-FORBRYDERNE/mtj-softtuner to create soft prompts in this format.