### PR TITLE
Official transformers 6B breakmodel support and more RAM-efficient model loading

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -303,6 +303,7 @@ def device_config(model):
     gc.collect()
     GPTNeoModel.forward = breakmodel.new_forward
     generator = model.generate
+    breakmodel.move_hidden_layers(model.transformer)
 
 #==================================================================#
 # Startup

--- a/aiserver.py
+++ b/aiserver.py
@@ -14,7 +14,8 @@ from tkinter import messagebox
 import json
 import collections
 import zipfile
-from typing import Union, Dict, Set, List
+import packaging
+from typing import Any, Union, Dict, Set, List
 
 import requests
 import html
@@ -541,6 +542,7 @@ if(not vars.model in ["InferKit", "Colab", "OAI", "ReadOnly", "TPUMeshTransforme
         print("{0}Initializing transformers, please wait...{1}".format(colors.PURPLE, colors.END))
         from transformers import StoppingCriteria, GPT2Tokenizer, GPT2LMHeadModel, GPTNeoForCausalLM, GPTNeoModel, AutoModelForCausalLM
         import transformers.generation_utils
+        from transformers import __version__ as transformers_version
 
         # Patch transformers to use our soft prompt
         def patch_causallm(cls):
@@ -701,15 +703,21 @@ if(not vars.model in ["InferKit", "Colab", "OAI", "ReadOnly", "TPUMeshTransforme
                     return int(model.transformer.embed_dim)
                 except:
                     return int(model.lm_head.in_features)
+        
+        def maybe_low_cpu_mem_usage() -> Dict[str, Any]:
+            if(packaging.version.parse(transformers_version) < packaging.version.parse("4.11.0")):
+                print(f"\nWARNING:  Please upgrade to transformers 4.11.0 for lower RAM usage.  You have transformers {transformers_version}.", file=sys.stderr)
+                return {}
+            return {"low_cpu_mem_usage": True}
 
         # If custom GPT Neo model was chosen
         if(vars.model == "NeoCustom"):
             model_config = open(vars.custmodpth + "/config.json", "r")
             js   = json.load(model_config)
             if("model_type" in js):
-                model     = AutoModelForCausalLM.from_pretrained(vars.custmodpth, cache_dir="cache/")
+                model     = AutoModelForCausalLM.from_pretrained(vars.custmodpth, cache_dir="cache/", **maybe_low_cpu_mem_usage())
             else:
-                model     = GPTNeoForCausalLM.from_pretrained(vars.custmodpth, cache_dir="cache/")
+                model     = GPTNeoForCausalLM.from_pretrained(vars.custmodpth, cache_dir="cache/", **maybe_low_cpu_mem_usage())
             vars.modeldim = get_hidden_size_from_model(model)
             tokenizer = GPT2Tokenizer.from_pretrained(vars.custmodpth, cache_dir="cache/")
             # Is CUDA available? If so, use GPU, otherwise fall back to CPU
@@ -727,8 +735,8 @@ if(not vars.model in ["InferKit", "Colab", "OAI", "ReadOnly", "TPUMeshTransforme
         elif(vars.model == "GPT2Custom"):
             model_config = open(vars.custmodpth + "/config.json", "r")
             js   = json.load(model_config)
-            model     = GPT2LMHeadModel.from_pretrained(vars.custmodpth, cache_dir="cache/")
-            tokenizer = GPT2Tokenizer.from_pretrained(vars.custmodpth, cache_dir="cache/")
+            model     = GPT2LMHeadModel.from_pretrained(vars.custmodpth, cache_dir="cache/", **maybe_low_cpu_mem_usage())
+            tokenizer = GPT2Tokenizer.from_pretrained(vars.custmodpth, cache_dir="cache/", **maybe_low_cpu_mem_usage())
             vars.modeldim = get_hidden_size_from_model(model)
             # Is CUDA available? If so, use GPU, otherwise fall back to CPU
             if(vars.hascuda and vars.usegpu):
@@ -742,20 +750,20 @@ if(not vars.model in ["InferKit", "Colab", "OAI", "ReadOnly", "TPUMeshTransforme
             tokenizer = GPT2Tokenizer.from_pretrained(vars.model, cache_dir="cache/")
             if(vars.hascuda):
                 if(vars.usegpu):
-                    model = AutoModelForCausalLM.from_pretrained(vars.model, cache_dir="cache/")
+                    model = AutoModelForCausalLM.from_pretrained(vars.model, cache_dir="cache/", **maybe_low_cpu_mem_usage())
                     vars.modeldim = get_hidden_size_from_model(model)
                     model = model.half().to(0)
                     generator = model.generate
                 elif(vars.breakmodel):  # Use both RAM and VRAM (breakmodel)
-                    model = AutoModelForCausalLM.from_pretrained(vars.model, cache_dir="cache/")
+                    model = AutoModelForCausalLM.from_pretrained(vars.model, cache_dir="cache/", **maybe_low_cpu_mem_usage())
                     vars.modeldim = get_hidden_size_from_model(model)
                     device_config(model)
                 else:
-                    model = AutoModelForCausalLM.from_pretrained(vars.model, cache_dir="cache/")
+                    model = AutoModelForCausalLM.from_pretrained(vars.model, cache_dir="cache/", **maybe_low_cpu_mem_usage())
                     vars.modeldim = get_hidden_size_from_model(model)
                     generator = model.generate
             else:
-                model = AutoModelForCausalLM.from_pretrained(vars.model, cache_dir="cache/")
+                model = AutoModelForCausalLM.from_pretrained(vars.model, cache_dir="cache/", **maybe_low_cpu_mem_usage())
                 vars.modeldim = get_hidden_size_from_model(model)
                 generator = model.generate
         

--- a/aiserver.py
+++ b/aiserver.py
@@ -542,6 +542,10 @@ if(not vars.model in ["InferKit", "Colab", "OAI", "ReadOnly", "TPUMeshTransforme
     if(not vars.noai):
         print("{0}Initializing transformers, please wait...{1}".format(colors.PURPLE, colors.END))
         from transformers import StoppingCriteria, GPT2Tokenizer, GPT2LMHeadModel, GPTNeoForCausalLM, GPTNeoModel, AutoModelForCausalLM
+        try:
+            from transformers import GPTJModel
+        except:
+            pass
         import transformers.generation_utils
         from transformers import __version__ as transformers_version
 

--- a/aiserver.py
+++ b/aiserver.py
@@ -298,10 +298,12 @@ def device_config(model):
     model.transformer.ln_f.to(breakmodel.primary_device)
     if(hasattr(model, 'lm_head')):
         model.lm_head.to(breakmodel.primary_device)
-    if(not hasattr(model.config, 'rotary') or not model.config.rotary):
+    if(hasattr(model.transformer, 'wpe')):
         model.transformer.wpe.to(breakmodel.primary_device)
     gc.collect()
     GPTNeoModel.forward = breakmodel.new_forward
+    if("GPTJModel" in globals()):
+        GPTJModel.forward = breakmodel.new_forward
     generator = model.generate
     breakmodel.move_hidden_layers(model.transformer)
 

--- a/aiserver.py
+++ b/aiserver.py
@@ -749,7 +749,7 @@ if(not vars.model in ["InferKit", "Colab", "OAI", "ReadOnly", "TPUMeshTransforme
             js   = json.load(model_config)
             with(maybe_use_float16()):
                 model = GPT2LMHeadModel.from_pretrained(vars.custmodpth, cache_dir="cache/", **maybe_low_cpu_mem_usage())
-            tokenizer = GPT2Tokenizer.from_pretrained(vars.custmodpth, cache_dir="cache/", **maybe_low_cpu_mem_usage())
+            tokenizer = GPT2Tokenizer.from_pretrained(vars.custmodpth, cache_dir="cache/")
             vars.modeldim = get_hidden_size_from_model(model)
             # Is CUDA available? If so, use GPU, otherwise fall back to CPU
             if(vars.hascuda and vars.usegpu):

--- a/breakmodel.py
+++ b/breakmodel.py
@@ -325,33 +325,27 @@ def new_forward(
     # Attention mask.
     if attention_mask is not None:
         assert batch_size > 0, "batch_size has to be defined and > 0"
-        global_attention_mask = attention_mask.view(batch_size, -1)
+        attention_mask = attention_mask.view(batch_size, -1)
         # We create a 3D attention mask from a 2D tensor mask.
         # Sizes are [batch_size, 1, 1, to_seq_length]
         # So we can broadcast to [batch_size, num_heads, from_seq_length, to_seq_length]
         # this attention mask is more simple than the triangular masking of causal attention
         # used in OpenAI GPT, we just need to prepare the broadcast dimension here.
-        global_attention_mask = global_attention_mask[:, None, None, :]
+        attention_mask = attention_mask[:, None, None, :]
 
-        # Since global_attention_mask is 1.0 for positions we want to attend and 0.0 for
+        # Since attention_mask is 1.0 for positions we want to attend and 0.0 for
         # masked positions, this operation will create a tensor which is 0.0 for
         # positions we want to attend and -10000.0 for masked positions.
         # Since we are adding it to the raw scores before the softmax, this is
         # effectively the same as removing these entirely.
-        global_attention_mask = global_attention_mask.to(dtype=self.dtype)  # fp16 compatibility
-        global_attention_mask = (1.0 - global_attention_mask) * -10000.0
-    else:
-        global_attention_mask = None
-
-    # Local causal attention mask
-    batch_size, seq_length = input_shape
-    full_seq_length = seq_length + past_length
+        attention_mask = attention_mask.to(dtype=self.dtype)  # fp16 compatibility
+        attention_mask = (1.0 - attention_mask) * -10000.0
 
     # Prepare head mask if needed
     # 1.0 in head_mask indicate we keep the head
     # attention_probs has shape bsz x num_heads x N x N
     # head_mask has shape n_layer x batch x num_heads x N x N
-    head_mask = self.get_head_mask(head_mask, self.config.num_layers)
+    head_mask = self.get_head_mask(head_mask, getattr(self.config, "num_layers", None) or self.config.n_layer)
 
     if inputs_embeds is None:
         if breakmodel:
@@ -367,7 +361,7 @@ def new_forward(
             inputs_embeds[:, pos:pos+emb.shape[1]] = emb
             offset += emb.shape[1]
 
-    if hasattr(self, 'rotary') and self.rotary:
+    if getattr(self, "wpe", None) is None:
         hidden_states = inputs_embeds
     else:
         if breakmodel:
@@ -403,9 +397,6 @@ def new_forward(
                     with torch.cuda.stream(copystream):
                         torch.cuda.comm.broadcast(param2.data,out = [param1.data])
 
-        attn_type = self.config.attention_layers[i]
-        attn_mask = global_attention_mask
-
         if output_hidden_states:
             all_hidden_states = all_hidden_states + (hidden_states.cpu(),)
 
@@ -413,8 +404,7 @@ def new_forward(
 
             if use_cache:
                 logger.warning(
-                    "`use_cache=True` is incompatible with `config.gradient_checkpointing=True`. Setting "
-                    "`use_cache=False`..."
+                    "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`..."
                 )
                 use_cache = False
 
@@ -429,7 +419,7 @@ def new_forward(
                 create_custom_forward(block),
                 hidden_states,
                 None,
-                attn_mask,
+                attention_mask,
                 head_mask[i],
             )
         else:
@@ -438,7 +428,7 @@ def new_forward(
             outputs = block(
                 hidden_states.to(device) if breakmodel and hidden_states is not None else hidden_states,
                 layer_past=tuple(v.to(device) for v in layer_past if v is not None) if breakmodel and layer_past is not None and i >= ram_blocks and len(layer_past) and layer_past[0].device.index != device else layer_past,
-                attention_mask=attn_mask.to(device) if breakmodel and attn_mask is not None else attn_mask,
+                attention_mask=attention_mask.to(device) if breakmodel and attention_mask is not None else attention_mask,
                 head_mask=head_mask[i].to(device) if breakmodel and head_mask[i] is not None else head_mask[i],
                 use_cache=use_cache,
                 output_attentions=output_attentions,


### PR DESCRIPTION
* You can now use breakmodel with 6B models on official transformers, but only with official transformers 4.11.0 or higher
* Loading a model *when not using pure CPU generation* now takes RAM approximately equal to the size of the pytorch_model.bin file instead of roughly 2-4 times as much, but only with official transformers 4.11.0 or higher (finetune's transformers does not support this so it will be disabled if you are using it)
* Loading a model using breakmodel now moves layers to the GPU before the browser opens -- rather than during the first generation -- to conserve RAM