### PR TITLE
Fixes OSError: Protocol  not found

### DIFF
--- a/docker-cuda/docker-compose.yml
+++ b/docker-cuda/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     network_mode: "host"
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix
+      - /etc/protocols:/etc/protocols:ro
       - ../:/content/
       - $HOME/.Xauthority:/home/micromamba/.Xauthority:rw
     devices:


### PR DESCRIPTION
Fixes an issue with tcp not being found in the protocols list. Im unsure if this issue is present in the rocm version as well.