### PR TITLE
Divide GPT-NeoX replicated bias layers by 4 again instead of by 8

### DIFF
--- a/tpu_mtj_backend.py
+++ b/tpu_mtj_backend.py
@@ -885,7 +885,7 @@ def read_neox_checkpoint(state, path, config, checkpoint_shards=2):
             original_shape = shards[0][key].shape
             for checkpoint_shard in range(checkpoint_shards):
                 if key in ("attention.dense.bias", "mlp.dense_4h_to_h.bias"):
-                    shards[checkpoint_shard][key] /= config["cores_per_replica"]
+                    shards[checkpoint_shard][key] /= output_shards
                 if key != "word_embeddings.weight" and shards[checkpoint_shard][key].ndim == 2:
                     shards[checkpoint_shard][key] = shards[checkpoint_shard][key].T
                 tensor = shards[checkpoint_shard][key]


### PR DESCRIPTION
I keep changing what the divisor is when converting NeoX models, but now I know definitively that it should be `output_shards` (which is equal to 4) and not `config["cores_per_replica"]` (which is equal to 8) because I ran a LAMBADA evaluation with different divisor values. 4 is clearly the correct divisor based on the table below (lower perplexity is better and higher accuracy is also better):


| Divisor | Perplexity (ppl) | Accuracy (acc) |
| --: | --: | --: |
| 1 | 1496384.602176 | 0.000000 |
| 2 | 6.987766 | 0.604890 |
| 4 | 4.020072 | 0.700951 |
| 8 | 4.855649 | 0.665049 |
| 16 | 6.099564 | 0.615758 |

I used this notebook to run the evaluations on the model with different divisor values:

https://colab.research.google.com/drive/1eyYBy9VDoOCwhonUQ6todcnNGWMM4Zau

You can change the value of the `DIVISOR` variable at the beginning of the second cell of the notebook.