### PR TITLE
Lazy loader Python 3.6 compatibility

### DIFF
--- a/torch_lazy_loader.py
+++ b/torch_lazy_loader.py
@@ -95,7 +95,7 @@ class LazyTensor:
         nbytes = size if dtype is torch.bool else size * ((torch.finfo if dtype.is_floating_point else torch.iinfo)(dtype).bits >> 3)
         if isinstance(checkpoint, zipfile.ZipFile):
             f = checkpoint.open(f"archive/data/{self.key}", "r")
-            f.seek(self.seek_offset)
+            f.read(self.seek_offset)
         else:
             f = checkpoint
         try:


### PR DESCRIPTION
The current lazy loader relies on a feature of the Python zipfile module that was added in Python 3.7.0:

https://bugs.python.org/issue22908

This commit adds compatibility for Python 3.6.