### PR TITLE
Remove Ray from requirements_mtj.txt

### DIFF
--- a/requirements_mtj.txt
+++ b/requirements_mtj.txt
@@ -4,7 +4,6 @@ tqdm
 requests
 optax >= 0.0.5, <= 0.0.9
 dm-haiku == 0.0.5
-ray[default]
 jax == 0.2.21
 transformers >= 4.17
 progressbar2


### PR DESCRIPTION
I made some changes recently to mesh transformer JAX so that we don't need Ray anymore. This should make the installation a little faster.