### PR TITLE
Fix lazy loader

### DIFF
--- a/tpu_mtj_backend.py
+++ b/tpu_mtj_backend.py
@@ -1176,7 +1176,7 @@ def load_model(path: str, driver_version="tpu_driver0.1_dev20210607", hf_checkpo
                         continue
 
                     storage_key = model_dict[key].key
-                    if storage_key != last_storage_key:
+                    if storage_key != last_storage_key or model_dict[key].seek_offset < current_offset:
                         last_storage_key = storage_key
                         if isinstance(f, zipfile.ZipExtFile):
                             f.close()


### PR DESCRIPTION
https://github.com/henk717/KoboldAI/pull/108 apparently prevented the lazy loader from loading new Janeway models properly in TPU Colabs.

The first commit is a fix that allows the new Janeway models to work in TPU Colabs again.

The second commit copies the changes from https://github.com/henk717/KoboldAI/pull/108 to aiserver.py so that the lazy loader is also compatible with Python 3.6 when running KoboldAI locally. I forgot to copy the changes to aiserver.py last time, which is why the Janeway models work locally.