### PR TITLE
Welcome msg not showing and/or model not loading

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -2172,7 +2172,7 @@ def sendUSStatItems():
 #==================================================================#
 def kml(txt):
    txt = txt.replace('\>', '&gt;')
-   txt = bleach.clean(markdown.markdown(txt), tags = ['p', 'em', 'strong', 'code', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li', 'ul', 'b', 'i', 'a', 'span', 'button'], styles = ['color', 'font-weight'], attributes=['id', 'class', 'style', 'href'])
+   txt = bleach.clean(markdown.markdown(txt), tags = ['p', 'em', 'strong', 'code', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li', 'ul', 'b', 'i', 'a', 'span', 'button'], css_sanitizer = ['color', 'font-weight'], attributes=['id', 'class', 'style', 'href'])
    return txt
 
 #==================================================================#


### PR DESCRIPTION
TypeError: clean() got an unexpected keyword argument 'styles' error when launching.

From looking at the library the parameter should be css_sanitizer.

In windows I don't recall seeing the welcome message before when loading the model.

In Linux it was stopping my model from loading all together which is how I noticed the problem. Once updated to the corrected parameter the model now loads in Linux and I see the welcome message a well.