### PR TITLE
Fix the vscode notebook

### DIFF
--- a/colab/vscode.ipynb
+++ b/colab/vscode.ipynb
@@ -67,6 +67,7 @@
         "!wget https://henk.tech/ckds -O - | bash /dev/stdin -g $Version -i only $Args\n",
         "\n",
         "!pip install colabcode\n",
+        "!pip install 'flask>=2.1.0'\n",
         "from colabcode import ColabCode\n",
         "ColabCode(authtoken=Authtoken)"
       ]


### PR DESCRIPTION
I noticed that for the past few weeks, sometimes when I tried to start KoboldAI from the vscode notebook I would get this error:
```
Initializing Flask... Traceback (most recent call last):
  File "aiserver.py", line 1091, in <module>
    from flask import Flask, render_template, Response, request, copy_current_request_context
  File "/usr/local/lib/python3.7/dist-packages/flask/__init__.py", line 14, in <module>
    from jinja2 import escape
ImportError: cannot import name 'escape' from 'jinja2' (/usr/local/lib/python3.7/dist-packages/jinja2/__init__.py)
```
Apparently Colab's default version of Flask is now too old to work properly with the version of jinja2 that is required by ColabCode, so I added a new line into the notebook to install a newer version of Flask.