### PR TITLE
Aria2 downloader bug fixes

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -135,7 +135,7 @@ def decodenewlines(txt):
 #==================================================================#
 #  Downloads sharded huggingface checkpoints using aria2c if possible
 #==================================================================#
-def aria2_hook(pretrained_model_name_or_path: str, force_download=True, cache_dir=None, proxies=None, resume_download=False, local_files_only=False, use_auth_token=None, user_agent=None, revision=None, mirror=None, **kwargs):
+def aria2_hook(pretrained_model_name_or_path: str, force_download=False, cache_dir=None, proxies=None, resume_download=False, local_files_only=False, use_auth_token=None, user_agent=None, revision=None, mirror=None, **kwargs):
     import transformers
     import transformers.modeling_utils
     from huggingface_hub import HfFolder

--- a/utils.py
+++ b/utils.py
@@ -200,7 +200,7 @@ def aria2_hook(pretrained_model_name_or_path: str, force_download=False, cache_d
     with tempfile.NamedTemporaryFile("w+b", delete=False) as f:
         f.write(aria2_config)
         f.flush()
-        p = subprocess.Popen(["aria2c", "-x", "10", "-s", "10", "-j", "10", "--disable-ipv6", "--file-allocation=none", "-d", _cache_dir, "-i", f.name, "-U", transformers.file_utils.http_user_agent(user_agent)] + (["-c"] if not force_download else []) + ([f"--header='Authorization: Bearer {token}'"] if use_auth_token else []), stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        p = subprocess.Popen(["aria2c", "-x", "10", "-s", "10", "-j", "10", "--disable-ipv6", "--file-allocation=trunc", "-d", _cache_dir, "-i", f.name, "-U", transformers.file_utils.http_user_agent(user_agent)] + (["-c"] if not force_download else []) + ([f"--header='Authorization: Bearer {token}'"] if use_auth_token else []), stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         for line in p.stdout:
             print(line.decode(), end="", flush=True)
         path = f.name

--- a/utils.py
+++ b/utils.py
@@ -186,11 +186,6 @@ def aria2_hook(pretrained_model_name_or_path: str, force_download=False, cache_d
             map_data = json.load(f)
         filenames = set(map_data["weight_map"].values())
     urls = [transformers.file_utils.hf_bucket_url(pretrained_model_name_or_path, n, revision=revision, mirror=mirror) for n in filenames]
-    if not force_download:
-        if all(is_cached(u) for u in urls):
-            return
-        elif local_files_only:
-            raise FileNotFoundError("Cannot find the requested files in the cached path and outgoing traffic has been disabled. To enable model look-ups and downloads online, set 'local_files_only' to False.")
     etags = [h.get("X-Linked-Etag") or h.get("ETag") for u in urls for h in [requests.head(u, headers=headers, allow_redirects=False, proxies=proxies, timeout=10).headers]]
     filenames = [transformers.file_utils.url_to_filename(u, t) for u, t in zip(urls, etags)]
     if force_download:

--- a/utils.py
+++ b/utils.py
@@ -198,6 +198,9 @@ def aria2_hook(pretrained_model_name_or_path: str, force_download=False, cache_d
             path = os.path.join(_cache_dir, n + ".json")
             if os.path.exists(path):
                 os.remove(path)
+            path = os.path.join(_cache_dir, n)
+            if os.path.exists(path):
+                os.remove(path)
     aria2_config = "\n".join(f"{u}\n  out={n}" for u, n in zip(urls, filenames)).encode()
     with tempfile.NamedTemporaryFile("w+b", delete=False) as f:
         f.write(aria2_config)


### PR DESCRIPTION
This changes the behaviour of the downloader so that it downloads files to a temporary filename and then renames the file after it's finished downloading, so that if you cancel a download, uninstall aria2 and then resume the download with the normal transformers downloader, transformers will delete the partially downloaded file instead of attempting to load from the partially downloaded file.

Also fixes a few minor issues with the `force_download` and `local_files_only` arguments.