### PR TITLE
Handle aria2 properly when it exits with nonzero exit code

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -218,6 +218,9 @@ def aria2_hook(pretrained_model_name_or_path: str, force_download=False, cache_d
         os.remove(path)
     except OSError:
         pass
+    code = p.wait()
+    if code:
+        raise OSError(f"aria2 exited with exit code {code}")
     for u, t, n in zip(urls, etags, filenames):
         os.rename(os.path.join(_cache_dir, "kai-tempfile." + n), os.path.join(_cache_dir, n))
         with open(os.path.join(_cache_dir, n + ".json"), "w") as f:


### PR DESCRIPTION
If you close the terminal window in Windows (instead of pressing CTRL+C) while aria2 is downloading a model, it will exit with some nonzero exit code and then the rest of the `aria2_hook()` function will run. This pull request makes the function stop running if aria2 exits with nonzero exit code.