### PR TITLE
Delete all torch tensors before loading model

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -1528,6 +1528,14 @@ def load_model(use_gpu=True, gpu_layers=None, disk_layers=None, initial_load=Fal
     model = None
     generator = None
     model_config = None
+    for tensor in gc.get_objects():
+        try:
+            if torch.is_tensor(tensor):
+                with torch.no_grad():
+                    tensor.set_(torch.tensor((), device=tensor.device, dtype=tensor.dtype))
+        except:
+            pass
+    gc.collect()
     try:
         torch.cuda.empty_cache()
     except:


### PR DESCRIPTION
This allows models to be properly freed from memory so that you can load a different model without restarting KoboldAI without requiring extra memory.