### PR TITLE
Story whitespace cleanup

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -5473,7 +5473,8 @@ def loadRequest(loadpath, filename=None):
             for text in js['actions']:
                 vars.actions_metadata[i] = {'Selected Text': text, 'Alternative Text': []}
                 i+=1
-                
+
+        footer = ""                
 
         if(len(vars.prompt.strip()) == 0):
             while(len(actions)):
@@ -5483,9 +5484,25 @@ def loadRequest(loadpath, filename=None):
                     break
             else:
                 vars.gamestarted = False
+        vars.prompt = vars.prompt.lstrip()
+        ln = len(vars.prompt.rstrip())
+        footer += vars.prompt[ln:]
+        vars.prompt = vars.prompt[:ln]
         if(vars.gamestarted):
             for s in actions:
-                vars.actions.append(s)
+                if(len(s.strip()) == 0):
+                    # If this action only contains whitespace, we merge it with the next action
+                    footer += s
+                    continue
+                vars.actions.append(footer + s)
+                footer = ""
+                # If there is trailing whitespace at the end of an action, we move that whitespace to the beginning of the next action
+                ln = len(vars.actions[vars.actions.get_last_key()].rstrip())
+                footer += vars.actions[vars.actions.get_last_key()][ln:]
+                vars.actions[vars.actions.get_last_key()] = vars.actions[vars.actions.get_last_key()][:ln]
+            if(len(vars.actions) == 0):
+                vars.gamestarted = False
+
         
         # Try not to break older save files
         if("authorsnote" in js):

--- a/static/application.js
+++ b/static/application.js
@@ -1717,7 +1717,7 @@ function applyChunkDeltas(nodes) {
 		var selected_chunks = buildChunkSetFromNodeArray(getSelectedNodes());
 		for(var i = 0; i < chunks.length; i++) {
 			var chunk = document.getElementById("n" + chunks[i]);
-			if(chunk && formatChunkInnerText(chunk).length != 0 && chunks[i] != '0') {
+			if(chunk && formatChunkInnerText(chunk).trim().length != 0 && chunks[i] != '0') {
 				if(!selected_chunks.has(chunks[i])) {
 					modified_chunks.delete(chunks[i]);
 					socket.send({'cmd': 'inlineedit', 'chunk': chunks[i], 'data': formatChunkInnerText(chunk)});
@@ -1726,7 +1726,7 @@ function applyChunkDeltas(nodes) {
 			} else {
 				if(!selected_chunks.has(chunks[i])) {
 					modified_chunks.delete(chunks[i]);
-					socket.send({'cmd': 'inlineedit', 'chunk': chunks[i], 'data': ''});
+					socket.send({'cmd': 'inlineedit', 'chunk': chunks[i], 'data': formatChunkInnerText(chunk)});
 				}
 				empty_chunks.add(chunks[i]);
 			}
@@ -1858,6 +1858,46 @@ function highlightEditingChunks() {
 	}
 }
 
+function cleanupChunkWhitespace() {
+	// Merge empty chunks with the next chunk
+	var chunks = Array.from(empty_chunks);
+	chunks.sort(function(e) {parseInt(e)});
+	for(var i = 0; i < chunks.length; i++) {
+		var original_chunk = document.getElementById("n" + chunks[i]);
+		original_chunk.innerText = footer + original_chunk.innerText;
+		footer = "";
+		var chunk = original_chunk.nextSibling;
+		while(chunk) {
+			if(chunk.tagName === "CHUNK") {
+				break;
+			}
+			chunk = chunk.nextSibling;
+		}
+		if(chunk) {
+			chunk.innerText = original_chunk.innerText + chunk.innerText;
+		}
+		original_chunk.innerText = "";
+	}
+	// Move whitespace at the end of non-empty chunks into the beginning of the next non-empty chunk
+	var chunks = Array.from(modified_chunks);
+	chunks.sort(function(e) {parseInt(e)});
+	for(var i = 0; i < chunks.length; i++) {
+		var original_chunk = document.getElementById("n" + chunks[i]);
+		var chunk = original_chunk.nextSibling;
+		while(chunk) {
+			if(chunk.tagName === "CHUNK" && !empty_chunks.has(chunk.getAttribute("n"))) {
+				break;
+			}
+			chunk = chunk.nextSibling;
+		}
+		var ln = original_chunk.innerText.trimEnd().length;
+		if (chunk) {
+			chunk.innerText = original_chunk.innerText.substring(ln) + chunk.innerText;
+		}
+		original_chunk.innerText = original_chunk.innerText.substring(0, ln);
+	}
+}
+
 // This gets run every time the text in a chunk is edited
 // or a chunk is deleted
 function chunkOnDOMMutate(mutations, observer) {
@@ -1936,6 +1976,7 @@ function chunkOnFocusOut(event) {
 		if(document.activeElement === game_text[0] || game_text[0].contains(document.activeElement)) {
 			return;
 		}
+		cleanupChunkWhitespace();
 		syncAllModifiedChunks(true);
 		setTimeout(function() {
 			var blurred = game_text[0] !== document.activeElement;

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,7 +17,7 @@
 	<script src="static/bootstrap.min.js"></script>
 	<script src="static/bootstrap-toggle.min.js"></script>
 	<script src="static/rangy-core.min.js"></script>
-	<script src="static/application.js?ver=1.18.1c"></script>
+	<script src="static/application.js?ver=1.18.1d"></script>
 	<script src="static/favicon.js"></script>
 	{% if flaskwebgui %}
 	<script src="static/flask_web_gui.js"></script>


### PR DESCRIPTION
This pull request adds some experimental code for helping with whitespace-related issues in stories:
* Actions that contain only whitespace will be deleted and the whitespace will be put at the beginning of the next action, or removed if there is no next action.
* Actions that contain trailing whitespace will have the trailing whitespace moved to the beginning of the next action, or removed if there is no next action.
* The editor no longer collapses spaces (e.g. if you have two spaces in a row, the editor will now actually show two spaces instead of just one space).

Moving whitespace to the beginning of an action is beneficial because we use a separate `tokenizer.encode` call for every action in the story. The GPT-2 tokenizer and similar tokenizers expect there to be no whitespace at the end of the input, hence the moving of the whitespace to the beginnings of the actions.

This should resolve some of the whitespace-related issues filed by people on the main repo.