### PR TITLE
More story whitespace cleanup

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -3495,6 +3495,7 @@ def actionsubmit(data, actionmode=0, force_submit=False, force_prompt_gen=False,
         if(not vars.gamestarted):
             vars.submission = data
             execute_inmod()
+            vars.submission = re.sub(r"[^\S\r\n]*([\r\n]*)$", r"\1", vars.submission)  # Remove trailing whitespace, excluding newlines
             data = vars.submission
             if(not force_submit and len(data.strip()) == 0):
                 assert False
@@ -3553,6 +3554,7 @@ def actionsubmit(data, actionmode=0, force_submit=False, force_prompt_gen=False,
                 data = applyinputformatting(data)
             vars.submission = data
             execute_inmod()
+            vars.submission = re.sub(r"[^\S\r\n]*([\r\n]*)$", r"\1", vars.submission)  # Remove trailing whitespace, excluding newlines
             data = vars.submission
             # Dont append submission if it's a blank/continue action
             if(data != ""):

--- a/static/application.js
+++ b/static/application.js
@@ -891,6 +891,7 @@ function dosubmit(disallow_abort) {
 	if((disallow_abort || gamestate !== "wait") && !memorymode && !gamestarted && ((!adventure || !action_mode) && txt.trim().length == 0)) {
 		return;
 	}
+	chunkOnFocusOut("override");
 	input_text.val("");
 	hideMessage();
 	hidegenseqs();
@@ -1969,7 +1970,7 @@ function chunkOnKeyDownSelectionChange(event) {
 // This gets run when you defocus the editor by clicking
 // outside of the editor or by pressing escape or tab
 function chunkOnFocusOut(event) {
-	if(!gametext_bound || !allowedit || event.target !== game_text[0]) {
+	if(event !== "override" && (!gametext_bound || !allowedit || event.target !== game_text[0])) {
 		return;
 	}
 	setTimeout(function() {

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,7 +17,7 @@
 	<script src="static/bootstrap.min.js"></script>
 	<script src="static/bootstrap-toggle.min.js"></script>
 	<script src="static/rangy-core.min.js"></script>
-	<script src="static/application.js?ver=1.18.1d"></script>
+	<script src="static/application.js?ver=1.18.1e"></script>
 	<script src="static/favicon.js"></script>
 	{% if flaskwebgui %}
 	<script src="static/flask_web_gui.js"></script>

--- a/utils.py
+++ b/utils.py
@@ -104,6 +104,9 @@ def removespecialchars(txt, vars=None):
 # If the next action follows a sentence closure, add a space
 #==================================================================#
 def addsentencespacing(txt, vars):
+    # Don't add sentence spacing if submission is empty or starts with whitespace
+    if(len(txt) == 0 or len(txt) != len(txt.lstrip())):
+        return txt
     # Get last character of last action
     if(len(vars.actions) > 0):
         if(len(vars.actions[vars.actions.get_last_key()]) > 0):


### PR DESCRIPTION
This pull request makes it so that trailing whitespace is also removed when submitting text (the previous pull request only did this for edited actions) since Nerys and Janeway keep outputting "urch" and "iced" and other bizarre tokens when there is whitespace at the end of the input.

Also fixes an issue where retrying with "Add sentence spacing" on causes an action containing only a single space to be put at the end of the story. The way to reproduce this is to make a story where the penultimate action has a full stop at the end and then press retry to regenerate the last action while Add sentence spacing is on.